### PR TITLE
Use float abs for float values instead of integer abs

### DIFF
--- a/Swerve/src/main/cpp/infrastructure/SparkMax.cpp
+++ b/Swerve/src/main/cpp/infrastructure/SparkMax.cpp
@@ -1869,7 +1869,7 @@ std::tuple<bool, bool, std::string> SparkMax::VerifyConfig(const std::string_vie
     {
         if (std::get_if<double>(&value))
         {
-            const double delta = abs(std::get<double>(*actual_value) - std::get<double>(value));
+            const double delta = fabs(std::get<double>(*actual_value) - std::get<double>(value));
 
             equal_actual = delta <= std::numeric_limits<double>::epsilon();
         }
@@ -1887,7 +1887,7 @@ std::tuple<bool, bool, std::string> SparkMax::VerifyConfig(const std::string_vie
     {
         if (std::get_if<double>(&value))
         {
-            const double delta = abs(std::get<double>(default_value) - std::get<double>(value));
+            const double delta = fabs(std::get<double>(default_value) - std::get<double>(value));
 
             equal_default = delta <= std::numeric_limits<double>::epsilon();
         }


### PR DESCRIPTION
Without this fix, the effective epsilon for comparing float values was 1.0. By changing out `abs` (which operates on integers) to `fabs` (which operates on doubles), the effective epsilon is the `numeric_limits` epsilon as intended.